### PR TITLE
refactor: use optics + default extensions

### DIFF
--- a/app/Model/SQueue.hs
+++ b/app/Model/SQueue.hs
@@ -1,14 +1,10 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
-
-module Model.SQueue where
+module Model.SQueue (SlurmResponse (..), Meta (..), Plugin (..), SlurmInfo (..), SlurmVersion (..)) where
 
 import Data.Aeson (FromJSON (parseJSON), genericParseJSON)
 import Data.Aeson.Casing (aesonPrefix)
 import Data.Char (toLower)
 import Model.Job (Job)
+import Optics.Label ()
 
 -- | Main response structure
 data SlurmResponse = SlurmResponse
@@ -16,7 +12,9 @@ data SlurmResponse = SlurmResponse
     , errors :: [Text]
     , jobs :: [Job]
     }
-    deriving (Show, Generic, FromJSON)
+    deriving (Show, Generic)
+
+instance FromJSON SlurmResponse
 
 -- | Meta information about the response
 data Meta = Meta

--- a/app/UI/JobPanel.hs
+++ b/app/UI/JobPanel.hs
@@ -17,27 +17,14 @@ import Brick (
     (<=>),
  )
 import Brick.Widgets.Border (border)
-import Control.Lens ((^.))
 import qualified Data.Text as T
 import Model.Job (
-    Job,
-    cpus,
-    endTime,
-    exitCode,
+    ExitCode (..),
+    Job (..),
     formatTime,
-    jobId,
-    jobState,
-    memoryPerNode,
-    name,
-    nodes,
-    partition,
     showWith,
-    startTime,
-    stateReason,
-    status,
-    timeLimit,
-    userName,
  )
+import Optics.Operators ((^.))
 
 import Data.Time.Clock.System (systemToUTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
@@ -53,23 +40,23 @@ drawJobPanel job =
                 ]
 
         stateAttr stateName = attrName $ "jobState." <> toString stateName
-        jobStateWidget = foldr (\stateName widget -> withAttr (stateAttr $ stateName) (txt stateName) <=> widget) emptyWidget (job ^. jobState)
+        jobStateWidget = foldr (\stateName widget -> withAttr (stateAttr $ stateName) (txt stateName) <=> widget) emptyWidget (job ^. #jobState)
      in border . padBottom Max . padLeftRight 1 . vBox $
             [ hBox
                 [ withAttr (attrName "jobLabel") (str "Job ID: ")
-                , withAttr (attrName "jobValue") (txt . show $ job ^. jobId)
+                , withAttr (attrName "jobValue") (txt . show $ job ^. #jobId)
                 , withAttr (attrName "jobLabel") (str " State: ")
                 , jobStateWidget
                 ]
-            , labeledField "Name" (job ^. name)
-            , labeledField "User" (job ^. userName)
-            , labeledField "Partition" (job ^. partition)
-            , labeledField "Nodes" (job ^. nodes)
-            , labeledField "CPUs" (showWith show $ job ^. cpus)
-            , labeledField "Memory/Node" (showWith (\mem -> show mem <> " MB") (job ^. memoryPerNode))
-            , labeledField "Time Limit" (showWith formatTime $ job ^. timeLimit)
-            , labeledField "Start Time" (showWith (toText . iso8601Show . systemToUTCTime) $ job ^. startTime)
-            , labeledField "End Time" (showWith (toText . iso8601Show . systemToUTCTime) $ job ^. endTime)
-            , labeledField "Exit Code" (T.intercalate " " $ job ^. exitCode ^. status)
-            , labeledField "State Reason" (job ^. stateReason)
+            , labeledField "Name" (job ^. #name)
+            , labeledField "User" (job ^. #userName)
+            , labeledField "Partition" (job ^. #partition)
+            , labeledField "Nodes" (job ^. #nodes)
+            , labeledField "CPUs" (showWith show $ job ^. #cpus)
+            , labeledField "Memory/Node" (showWith (\mem -> show mem <> " MB") (job ^. #memoryPerNode))
+            , labeledField "Time Limit" (showWith formatTime $ job ^. #timeLimit)
+            , labeledField "Start Time" (showWith (toText . iso8601Show . systemToUTCTime) $ job ^. #startTime)
+            , labeledField "End Time" (showWith (toText . iso8601Show . systemToUTCTime) $ job ^. #endTime)
+            , labeledField "Exit Code" (T.intercalate " " $ job ^. #exitCode ^. #status)
+            , labeledField "State Reason" (job ^. #stateReason)
             ]

--- a/app/UI/Poller.hs
+++ b/app/UI/Poller.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
-
-module UI.Poller (PollerState, PollEvent (..), drawPoller, poller, handlePollerEvent, currentFile, tailFile, startPoller, commandChannel, buffer, maxLines) where
+module UI.Poller (PollerState (..), PollEvent (..), drawPoller, poller, handlePollerEvent, tailFile, startPoller) where
 
 import Brick (
     EventM,
@@ -14,30 +11,32 @@ import Brick (
  )
 import Brick.Widgets.Border (borderWithLabel)
 import Control.Concurrent.STM.TChan (TChan, writeTChan)
-import Control.Lens (makeLenses, use, (.=), (^.))
 import qualified Data.Sequence as Seq
+import Optics.Label ()
+import Optics.Operators ((^.))
+import Optics.State (use)
+import Optics.State.Operators ((.=))
 
 import qualified Data.Text as T
 import Tail.Poller (Command (..), createPoller)
 
 data PollerState = PollerState
-    { _commandChannel :: TChan Command
-    , _buffer :: Either String (Seq Text)
-    , _maxLines :: Int
-    , _currentFile :: Maybe Text
+    { commandChannel :: TChan Command
+    , buffer :: Either String (Seq Text)
+    , maxLines :: Int
+    , currentFile :: Maybe Text
     }
-
-makeLenses ''PollerState
+    deriving (Generic)
 
 data PollEvent = PollError String | PollUpdate (Seq Text) deriving (Show)
 
 poller :: TChan Command -> Int -> PollerState
 poller chan maxLines' =
     PollerState
-        { _commandChannel = chan
-        , _buffer = Right mempty
-        , _maxLines = maxLines'
-        , _currentFile = Nothing
+        { commandChannel = chan
+        , buffer = Right mempty
+        , maxLines = maxLines'
+        , currentFile = Nothing
         }
 
 takeR :: Int -> Seq Text -> Seq Text
@@ -52,25 +51,25 @@ startPoller chan f = createPoller chan handle (pure ())
 
 tailFile :: FilePath -> EventM n PollerState ()
 tailFile fp = do
-    chan <- use commandChannel
+    chan <- use #commandChannel
     liftIO . atomically $ writeTChan chan (Tail fp)
-    buffer .= Right mempty
-    currentFile .= Just (toText fp)
+    #buffer .= Right mempty
+    #currentFile .= Just (toText fp)
 
 handlePollerEvent :: PollEvent -> EventM n PollerState ()
-handlePollerEvent (PollError err) = buffer .= (Left err)
+handlePollerEvent (PollError err) = #buffer .= (Left err)
 handlePollerEvent (PollUpdate buf) = do
-    currentBuffer <- use buffer
-    allowedLength <- use maxLines
-    buffer .= Right (takeR allowedLength (fromRight mempty currentBuffer <> buf))
+    currentBuffer <- use #buffer
+    allowedLength <- use #maxLines
+    #buffer .= Right (takeR allowedLength (fromRight mempty currentBuffer <> buf))
 
 pollTextWidget :: PollerState -> Widget n
-pollTextWidget (PollerState{_buffer = (Right lns)}) = txt . foldMap (<> "\n") $ lns
-pollTextWidget (PollerState{_buffer = (Left err)}) = str err
+pollTextWidget (PollerState{buffer = (Right lns)}) = txt . foldMap (<> "\n") $ lns
+pollTextWidget (PollerState{buffer = (Left err)}) = str err
 
 drawPoller :: PollerState -> Widget n
 drawPoller st =
-    case st ^. currentFile of
+    case st ^. #currentFile of
         Nothing -> emptyWidget
         Just fp ->
             borderWithLabel (txt fp) . padRight Max $ pollTextWidget st

--- a/app/UI/View.hs
+++ b/app/UI/View.hs
@@ -14,17 +14,11 @@ import Brick (
     (<=>),
  )
 import Brick.Widgets.Border (hBorder)
-import Control.Lens
+import Optics.Operators ((^.))
 
 import Model.AppState (
-    AppState,
-    Name,
-    currentTime,
-    jobQueueState,
-    pollState,
-    scontrolLogState,
-    showLog,
-    transient,
+    AppState (..),
+    Name (..),
  )
 import UI.JobList (drawJobList, drawSearchBar, selectedJob)
 import UI.JobPanel (drawJobPanel)
@@ -35,11 +29,11 @@ import UI.Transient (drawTransientView)
 -- | Top-level renderer for the entire application.
 drawApp :: AppState -> [Widget Name]
 drawApp st =
-    (if st ^. showLog then [drawSlurmCommandLog (st ^. scontrolLogState)] else [])
+    (if st ^. #showLog then [drawSlurmCommandLog (st ^. #scontrolLogState)] else [])
         <> [ vBox
-                [ (drawSearchBar (st ^. jobQueueState) <=> hBorder)
-                , (drawJobList (st ^. currentTime) (st ^. jobQueueState) <+> maybe emptyWidget drawJobPanel (st ^? jobQueueState . selectedJob))
-                , drawPoller (st ^. pollState)
-                , maybe emptyWidget drawTransientView (st ^. transient)
+                [ (drawSearchBar (st ^. #jobQueueState) <=> hBorder)
+                , (drawJobList (st ^. #currentTime) (st ^. #jobQueueState) <+> maybe emptyWidget drawJobPanel (selectedJob (st ^. #jobQueueState)))
+                , drawPoller (st ^. #pollState)
+                , maybe emptyWidget drawTransientView (st ^. #transient)
                 ]
            ]

--- a/slew.cabal
+++ b/slew.cabal
@@ -67,10 +67,10 @@ executable slew
     other-modules: Model.SQueue Model.Job UI.Transient Model.AppState UI.View UI.Event SQueue.Poller Tail.Poller UI.Poller UI.JobPanel UI.JobList Model.SlurmCommand UI.SlurmCommand
 
     -- LANGUAGE extensions used by modules in this package.
-    -- other-extensions:
+    default-extensions: OverloadedStrings DeriveGeneric NoFieldSelectors DuplicateRecordFields OverloadedRecordDot OverloadedLabels
 
     -- Other library packages from which modules are imported.
-    build-depends:    base >= 4.19.2.0, relude, brick, lens, vector, vty, fmt, linear, aeson, vty-crossplatform, bytestring, process, time, rosezipper, aeson-casing, async, hinotify, text, stm, text-zipper, optparse-applicative, brick-tabular-list
+    build-depends:    base >= 4.19.2.0, relude, brick, vector, vty, fmt, linear, aeson, vty-crossplatform, bytestring, process, time, rosezipper, aeson-casing, async, hinotify, text, stm, text-zipper, optparse-applicative, brick-tabular-list, optics-core, optics-extra
 
     -- Directories containing source files.
     hs-source-dirs:   app


### PR DESCRIPTION
Refactors to remove the lens dependency and simply the dependency tree with just `optics-core` and `optics-extra` for `StateT` operators.  