### PR TITLE
Add theming support

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,17 +5,13 @@ module Main where
 
 import Brick (
     App (..),
-    AttrMap,
-    attrMap,
-    attrName,
     customMain,
-    fg,
     showFirstCursor,
  )
 import qualified Brick.BChan as BC
+import Brick.Themes (Theme, themeToAttrMap)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync)
-import qualified Graphics.Vty as V
 import Graphics.Vty.Config (defaultConfig)
 import Graphics.Vty.CrossPlatform (mkVty)
 import Model.AppState (
@@ -25,72 +21,44 @@ import Model.AppState (
     initialState,
  )
 import Optics.Operators ((^.))
-import Options.Applicative (
-    Parser,
-    ParserInfo,
-    auto,
-    execParser,
-    fullDesc,
-    header,
-    help,
-    helper,
-    info,
-    long,
-    metavar,
-    option,
-    short,
-    showDefault,
-    value,
- )
+import Options.Applicative (Parser, ParserInfo, auto, execParser, fullDesc, header, help, helper, info, long, metavar, option, short, showDefault, str, value)
 import SQueue.Poller (squeueThread)
+import System.Environment.Blank (getEnv)
+import System.FilePath (combine)
+import System.IO (hPutStrLn)
 import UI.Event (handleEventWithEcho)
 import UI.Poller (PollerState (..), startPoller)
 import UI.SlurmCommand (SlurmCommandLogEntry (..), SlurmCommandLogState (..), startSlurmCommandListener)
+import UI.Themes (defaultTheme, loadTheme)
 import UI.View (drawApp)
 
 ------------------------------------------------------------
 -- Brick App Definition
 
-app :: App AppState SlewEvent Name
-app =
+app :: Theme -> App AppState SlewEvent Name
+app theme =
     App
         { appDraw = drawApp
         , appChooseCursor = showFirstCursor
         , appHandleEvent = handleEventWithEcho
         , appStartEvent = pure ()
-        , appAttrMap = const appAttrs
+        , appAttrMap = const (themeToAttrMap theme)
         }
-
-------------------------------------------------------------
--- Attribute Styles
-
-appAttrs :: AttrMap
-appAttrs =
-    attrMap
-        V.defAttr
-        [ (attrName "selected", V.withStyle V.defAttr V.reverseVideo)
-        , (attrName "highlight", fg V.cyan)
-        , (attrName "jobState.PENDING", fg V.yellow)
-        , (attrName "jobState.RUNNING", fg V.green)
-        , (attrName "jobState.COMPLETED", fg V.blue)
-        , (attrName "jobState.FAILED", fg V.red)
-        , (attrName "jobState.CANCELLED", fg V.red)
-        , (attrName "exitFailure", fg V.red)
-        , (attrName "exitSuccess", fg V.green)
-        , (attrName "jobLabel", fg V.cyan)
-        , (attrName "jobValue", fg V.white)
-        , (attrName "jobId", fg V.blue)
-        ]
 
 ------------------------------------------------------------
 -- Main
 
 data Options = Options
-    {pollInterval :: Int}
+    { pollInterval :: Int
+    , theme :: Maybe FilePath
+    }
     deriving (Generic)
 
 options :: Parser Options
-options = Options <$> (option auto (long "interval" <> short 'i' <> help "Polling interval for squeue commands. Keep short to keep your admins happy. Does not affect output viewing." <> showDefault <> value 30 <> metavar "TIME (s)"))
+options = Options <$> pollInterval <*> theme
+  where
+    pollInterval = option auto (long "interval" <> short 'i' <> help "Polling interval for squeue commands. Keep short to keep your admins happy. Does not affect output viewing." <> showDefault <> value 30 <> metavar "TIME (s)")
+    theme = optional (option str (long "theme" <> short 't' <> help "Path to a custom theme file" <> showDefault <> metavar "FILE"))
 
 cli :: ParserInfo Options
 cli = info (options <**> helper) (fullDesc <> header "slew - Slurm for the rest of us.")
@@ -98,16 +66,36 @@ cli = info (options <**> helper) (fullDesc <> header "slew - Slurm for the rest 
 tickThread :: IO () -> IO ()
 tickThread callback = forever (callback >> threadDelay 1_000_000)
 
+configDirectory :: IO (Maybe FilePath)
+configDirectory = do
+    home <- getEnv "HOME"
+    xdgConfig <- getEnv "XDG_CONFIG_HOME"
+    let
+        defaultConfigDir = combine <$> home <*> pure ".config"
+        config = xdgConfig <|> defaultConfigDir
+    return $ combine <$> config <*> pure "slew"
+
+withAsyncs :: [IO a] -> IO b -> IO b
+withAsyncs asyncs action = foldr (\async form -> withAsync async (\_ -> form)) action asyncs
+
 main :: IO ()
 main = do
+    opts <- execParser cli
     is <- initialState
     eventChannel <- BC.newBChan 50
-    opts <- execParser cli
-    withAsync (tickThread (BC.writeBChan eventChannel Tick)) $ \_ ->
-        withAsync (squeueThread (opts ^. #pollInterval) (is ^. #squeueChannel) (BC.writeBChan eventChannel . SQueueStatus)) $ \_ ->
-            withAsync (startPoller (is ^. #pollState ^. #commandChannel) (BC.writeBChan eventChannel . PollEvent)) $ \_ -> do
-                withAsync (startSlurmCommandListener (is ^. #scontrolLogState ^. #chan) (\cmd output -> BC.writeBChan eventChannel (SlurmCommandReceive (SlurmCommandLogEntry cmd output)))) $ \_ -> do
-                    let buildVty = mkVty defaultConfig
-
-                    initialVty <- buildVty
-                    void $ customMain initialVty buildVty (Just eventChannel) app is
+    slewConfigDirectory <- configDirectory
+    let slewThemePath = (opts ^. #theme) <|> combine <$> slewConfigDirectory <*> pure "theme.ini"
+        asyncActions =
+            [ tickThread (BC.writeBChan eventChannel Tick)
+            , squeueThread (opts ^. #pollInterval) (is ^. #squeueChannel) (BC.writeBChan eventChannel . SQueueStatus)
+            , startPoller (is ^. #pollState ^. #commandChannel) (BC.writeBChan eventChannel . PollEvent)
+            , startSlurmCommandListener (is ^. #scontrolLogState ^. #chan) (\cmd output -> BC.writeBChan eventChannel (SlurmCommandReceive (SlurmCommandLogEntry cmd output)))
+            ]
+    themeOrErr <- maybe (pure . Right $ defaultTheme) loadTheme slewThemePath
+    withAsyncs asyncActions $ do
+        let buildVty = mkVty defaultConfig
+        initialVty <- buildVty
+        theme <- case themeOrErr of
+            Right theme -> pure theme
+            Left err -> hPutStrLn stderr err >> hFlush stderr >> pure defaultTheme
+        void $ customMain initialVty buildVty (Just eventChannel) (app theme) is

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -4,6 +4,7 @@ module UI.Event (
 
 import Brick (BrickEvent (AppEvent, VtyEvent), EventM, halt, nestEventM, txt, zoom)
 import Brick.BChan (writeBChan)
+import Brick.Widgets.Core (withAttr)
 import Data.Time.Clock.System (getSystemTime)
 import qualified Graphics.Vty as V
 import Model.AppState (
@@ -24,6 +25,7 @@ import UI.Echo (clear, echo)
 import UI.JobList (handleJobQueueEvent, selectedJob, updateJobList, updateSortKey)
 import UI.Poller (handlePollerEvent, tailFile)
 import UI.SlurmCommand (SlurmCommandCmd (..), SlurmCommandLogEntry (SlurmCommandLogEntry, result), logSlurmCommandEvent, sendSlurmCommandCommand)
+import UI.Themes (header, transient)
 import UI.Transient (TransientMsg)
 import qualified UI.Transient as TR
 
@@ -39,14 +41,14 @@ scontrolTransient =
             [ TR.submenu 's' "State Control" $
                 TR.horizontalLayout
                     [ TR.verticalLayoutWithLabel
-                        (txt "Stop or Start")
+                        (withAttr (transient <> header) $ txt "Stop or Start")
                         [ TR.item 'h' "Hold" (SlurmCommandSend Hold)
                         , TR.item 'r' "Resume" (SlurmCommandSend Resume)
                         , TR.item 's' "Suspend" (SlurmCommandSend Suspend)
                         , TR.item 'c' "Cancel" (SlurmCommandSend Cancel)
                         ]
                     , TR.verticalLayoutWithLabel
-                        (txt "Priority")
+                        (withAttr (transient <> header) $ txt "Priority")
                         [ TR.item 't' "Top" (SlurmCommandSend Top)
                         ]
                     ]
@@ -56,13 +58,28 @@ sortTransient :: TR.TransientState SlewEvent Name
 sortTransient =
     TR.menu "Job Sorting" $
         TR.horizontalLayout
-            [ TR.item 'a' "Account" (SortBy Account)
-            , TR.item 'c' "CPUs" (SortBy CPUs)
-            , TR.item 's' "Start Time" (SortBy StartTime)
-            , TR.item 'e' "End Time" (SortBy EndTime)
-            , TR.item 'j' "Job Name" (SortBy JobName)
-            , TR.item 'u' "User Name" (SortBy UserName)
-            , TR.item 'm' "Memory (per node)" (SortBy Memory)
+            [ TR.verticalLayoutWithLabel
+                (withAttr (transient <> header) $ txt "Name of")
+                [ TR.item
+                    'a'
+                    "Account"
+                    (SortBy Account)
+                , TR.item
+                    'u'
+                    "User"
+                    (SortBy UserName)
+                , TR.item 'j' "Job" (SortBy JobName)
+                ]
+            , TR.verticalLayoutWithLabel
+                (withAttr (transient <> header) $ txt "Time")
+                [ TR.item 's' "Start Time" (SortBy StartTime)
+                , TR.item 'e' "End Time" (SortBy EndTime)
+                ]
+            , TR.verticalLayoutWithLabel
+                (withAttr (transient <> header) $ txt "Resources")
+                [ TR.item 'c' "CPUs" (SortBy CPUs)
+                , TR.item 'm' "Memory (per node)" (SortBy Memory)
+                ]
             ]
 
 sortListByCat :: Category -> Job -> Job -> Ordering

--- a/app/UI/JobList.hs
+++ b/app/UI/JobList.hs
@@ -47,9 +47,8 @@ import Brick.Widgets.TabularList.Mixed (
 
 import qualified Data.Text as T
 import qualified Graphics.Vty as V
-import Optics.At (ix)
 import Optics.Label ()
-import Optics.Operators ((^.), (^?))
+import Optics.Operators ((^.))
 import Optics.State (use)
 import Optics.State.Operators ((%=), (.=))
 

--- a/app/UI/JobPanel.hs
+++ b/app/UI/JobPanel.hs
@@ -28,6 +28,7 @@ import Optics.Operators ((^.))
 
 import Data.Time.Clock.System (systemToUTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
+import UI.Themes (jobLabel, jobState)
 
 -- | Render detailed job panel
 drawJobPanel :: Job -> Widget n
@@ -35,17 +36,17 @@ drawJobPanel job =
     let labeledField :: Text -> Text -> Widget n
         labeledField label value =
             hBox
-                [ withAttr (attrName "jobLabel") (txt (label <> ": "))
-                , withAttr (attrName "jobValue") (txt value)
+                [ withAttr jobLabel (txt (label <> ": "))
+                , txt value
                 ]
 
-        stateAttr stateName = attrName $ "jobState." <> toString stateName
+        stateAttr stateName = jobState <> attrName (toString stateName)
         jobStateWidget = foldr (\stateName widget -> withAttr (stateAttr $ stateName) (txt stateName) <=> widget) emptyWidget (job ^. #jobState)
      in border . padBottom Max . padLeftRight 1 . vBox $
             [ hBox
-                [ withAttr (attrName "jobLabel") (str "Job ID: ")
-                , withAttr (attrName "jobValue") (txt . show $ job ^. #jobId)
-                , withAttr (attrName "jobLabel") (str " State: ")
+                [ withAttr jobLabel (str "Job ID: ")
+                , (txt . show $ job ^. #jobId)
+                , withAttr jobLabel (str " State: ")
                 , jobStateWidget
                 ]
             , labeledField "Name" (job ^. #name)

--- a/app/UI/SlurmCommand.hs
+++ b/app/UI/SlurmCommand.hs
@@ -5,7 +5,6 @@ import Brick (
     Padding (Pad),
     ViewportType (Vertical),
     Widget,
-    attrName,
     emptyWidget,
     hBox,
     padLeftRight,
@@ -40,6 +39,7 @@ import Optics.Label ()
 import Optics.Operators ((^.))
 import Optics.State (use)
 import Optics.State.Operators ((%=))
+import UI.Themes (failure, jobId, success)
 
 data SlurmCommandCmd
     = CancelJob [Int]
@@ -119,15 +119,15 @@ formatShellCommand cmd =
     format name' ids =
         padLeftRight 1 (str name')
             <+> hBox
-                (map (\i -> padRight (Pad 1) $ withAttr (attrName "jobId") (txt . show $ i)) ids)
+                (map (\i -> padRight (Pad 1) $ withAttr jobId (txt . show $ i)) ids)
 
 drawEntry :: SlurmCommandLogEntry -> Widget n
 drawEntry (SlurmCommandLogEntry{command = com, result = res}) = vBox [commandLine, commandOutput]
   where
     commandLine = hBox [padRight (Pad 4) exitStatus, shellCommand]
     exitStatus = case res of
-        Left (SlurmCommandError{exitCode = e}) -> withAttr (attrName "exitFailure") (txt . show $ e)
-        Right _ -> withAttr (attrName "exitSuccess") (txt "0")
+        Left (SlurmCommandError{exitCode = e}) -> withAttr failure (txt . show $ e)
+        Right _ -> withAttr success (txt "0")
     commandOutput = case res of
         Left (SlurmCommandError{stderr = err}) -> str err
         Right (SlurmCommandOutput{stdout = out}) -> str out

--- a/app/UI/Transient.hs
+++ b/app/UI/Transient.hs
@@ -56,6 +56,7 @@ import qualified Graphics.Vty as V
 import Optics.Getter (view)
 import Optics.Label ()
 import Optics.Operators ((^.))
+import qualified UI.Themes as Th
 
 data TransientPrefix m n = TransientPrefix
     { char :: Char
@@ -101,11 +102,11 @@ menu rootName (TransientBuilder draw children) =
 
 -- | Create a simple action item
 item :: Char -> Text -> m -> TransientBuilder m n
-item c txt' cmd = leaf c mempty txt' cmd
+item c txt' cmd = leaf c (Th.transient <> Th.label) txt' cmd
 
 -- | Create a submenu
 submenu :: Char -> Text -> TransientBuilder m n -> TransientBuilder m n
-submenu c txt' = node c mempty txt'
+submenu c txt' = node c (Th.transient <> Th.submenu) txt'
 
 drawTransientView :: TransientState m n -> Widget n
 drawTransientView menu' = go (tree menu')

--- a/slew.cabal
+++ b/slew.cabal
@@ -64,13 +64,13 @@ executable slew
     main-is:          Main.hs
 
     -- Modules included in this executable, other than Main.
-    other-modules: Model.SQueue Model.Job UI.Transient Model.AppState UI.View UI.Event SQueue.Poller Tail.Poller UI.Poller UI.JobPanel UI.JobList Model.SlurmCommand UI.SlurmCommand UI.Echo
+    other-modules: Model.SQueue Model.Job UI.Transient Model.AppState UI.View UI.Event SQueue.Poller Tail.Poller UI.Poller UI.JobPanel UI.JobList Model.SlurmCommand UI.SlurmCommand UI.Echo UI.Themes
 
     -- LANGUAGE extensions used by modules in this package.
     default-extensions: OverloadedStrings DeriveGeneric NoFieldSelectors DuplicateRecordFields OverloadedRecordDot OverloadedLabels
 
     -- Other library packages from which modules are imported.
-    build-depends:    base >= 4.19.2.0, relude, brick, vector, vty, fmt, linear, aeson, vty-crossplatform, bytestring, process, time, rosezipper, aeson-casing, async, hinotify, text, stm, text-zipper, optparse-applicative, brick-tabular-list, optics-core, optics-extra
+    build-depends:    base >= 4.19.2.0, relude, brick, vector, vty, fmt, linear, aeson, vty-crossplatform, bytestring, process, time, rosezipper, aeson-casing, async, hinotify, text, stm, text-zipper, optparse-applicative, brick-tabular-list, optics-core, optics-extra, filepath
 
     -- Directories containing source files.
     hs-source-dirs:   app


### PR DESCRIPTION
This PR adds in the ability to read and theme slew, including but not limited to:

- The transient interface,
- Job states (including custom job states),
- Columns (including per column themes),
- Job ids and labels,
- row selections.

A sensible default theme is applied with minimal customisations. Themes are loaded from the following places, in order of priority:

1. The file given by `-t FILE` or `--theme FILE`,
2. `$XDG_CONFIG_HOME/slew/theme.ini` if it exists,
3. `~/.config/slew/theme.ini`, as a backup.

Errors loading the theme file are placed in the echo area at startup, and the default theme is used instead. 