### PR TITLE
Better job list

### DIFF
--- a/app/Model/AppState.hs
+++ b/app/Model/AppState.hs
@@ -39,6 +39,7 @@ data AppState = AppState
     , scontrolLogState :: SlurmCommandLogState Name
     , squeueChannel :: BChan ()
     , currentTime :: SystemTime
+    , lastUpdate :: Maybe SystemTime
     , showLog ::
         Bool
     , echoState :: EchoState
@@ -64,5 +65,6 @@ initialState = do
             , scontrolLogState = scontrolLog SlurmCommandLogView scontrolCommandChannel
             , showLog = False
             , currentTime = currentTime'
+            , lastUpdate = Nothing
             , echoState = echoStateWith initialMessage
             }

--- a/app/Model/Job.hs
+++ b/app/Model/Job.hs
@@ -99,7 +99,7 @@ normaliseDates job =
     normalise x = x
 
 convertTimeLimit :: Job -> Job
-convertTimeLimit = over #timeLimit (fmap (* 60)) -- Time limits appear to be in minutes rather seconds 
+convertTimeLimit = over #timeLimit (fmap (* 60)) -- Time limits appear to be in minutes rather seconds
 
 instance FromJSON Job where
     parseJSON = fmap (convertTimeLimit . normaliseDates) . genericParseJSON snakeCaseOptions
@@ -110,7 +110,7 @@ formatTime diff =
     let
         seconds = round diff :: Int
         days = seconds `div` 86400
-        hours = (seconds `mod` 86400)`div` 3600
+        hours = (seconds `mod` 86400) `div` 3600
         minutes = (seconds `mod` 3600) `div` 60
         secs = seconds `mod` 60
      in

--- a/app/Model/Job.hs
+++ b/app/Model/Job.hs
@@ -99,7 +99,7 @@ normaliseDates job =
     normalise x = x
 
 convertTimeLimit :: Job -> Job
-convertTimeLimit = over #timeLimit (fmap (* 60)) -- Time limits appear to be in minutes rather seconds
+convertTimeLimit = over #timeLimit (fmap (* 60)) -- Time limits appear to be in minutes rather than seconds
 
 instance FromJSON Job where
     parseJSON = fmap (convertTimeLimit . normaliseDates) . genericParseJSON snakeCaseOptions

--- a/app/Model/Job.hs
+++ b/app/Model/Job.hs
@@ -101,8 +101,9 @@ formatTime :: DiffTime -> Text
 formatTime diff =
     let
         seconds = round diff :: Int
-        hours = seconds `div` 3600
+        days = seconds `div` 86400
+        hours = (seconds `mod` 86400)`div` 3600
         minutes = (seconds `mod` 3600) `div` 60
         secs = seconds `mod` 60
      in
-        "" +| padLeftF 2 '0' hours |+ ":" +| padLeftF 2 '0' minutes |+ ":" +| padLeftF 2 '0' secs |+ ""
+        (if days > 0 then (padLeftF 2 '0' days +| "-") else "") +| padLeftF 2 '0' hours |+ ":" +| padLeftF 2 '0' minutes |+ ":" +| padLeftF 2 '0' secs |+ ""

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -34,6 +34,8 @@ triggerSqueue :: EventM n AppState ()
 triggerSqueue = do
     ch <- use #squeueChannel
     liftIO (writeBChan ch ())
+    curTime <- liftIO getSystemTime
+    #lastUpdate .= pure curTime
 
 scontrolTransient :: TR.TransientState SlewEvent Name
 scontrolTransient =

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -124,11 +124,12 @@ handleEvent (VtyEvent e@(V.EvKey V.KEsc [])) = do
         (True, _) -> #showLog .= False
         (False, Just TR.Close) -> #transient .= Nothing
         _ -> halt
-handleEvent (VtyEvent (V.EvKey (V.KChar 'q') [])) = halt
+handleEvent (VtyEvent (V.EvKey (V.KChar 'q') [V.MCtrl])) = halt
 handleEvent (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl])) =
     #transient .= Just scontrolTransient -- could parameterise this
 handleEvent (VtyEvent (V.EvKey (V.KChar 'o') [V.MCtrl])) = handleJobFile #standardOutput
 handleEvent (VtyEvent (V.EvKey (V.KChar 'e') [V.MCtrl])) = handleJobFile #standardError
+handleEvent (VtyEvent (V.EvKey (V.KChar 'r') [V.MCtrl])) = triggerSqueue
 handleEvent (VtyEvent (V.EvKey (V.KChar 's') [V.MCtrl])) =
     #transient .= Just sortTransient -- could parameterise this
 handleEvent (VtyEvent e) = do

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -34,6 +34,9 @@ triggerSqueue :: EventM n AppState ()
 triggerSqueue = do
     ch <- use #squeueChannel
     liftIO (writeBChan ch ())
+
+bumpUpdateTime :: EventM n AppState ()
+bumpUpdateTime = do
     curTime <- liftIO getSystemTime
     #lastUpdate .= pure curTime
 
@@ -141,7 +144,7 @@ handleEvent (VtyEvent e) = do
         Just (TR.Msg msg') -> #transient .= Nothing >> handleEvent (AppEvent msg')
         Just TR.Next -> pure ()
         _ -> zoom #jobQueueState (handleJobQueueEvent e)
-handleEvent (AppEvent (SQueueStatus jobs)) = zoom #jobQueueState (updateJobList jobs)
+handleEvent (AppEvent (SQueueStatus jobs)) = zoom #jobQueueState (updateJobList jobs) >> bumpUpdateTime
 handleEvent (AppEvent (SortBy category)) = zoom #jobQueueState (updateSortKey (sortListByCat category))
 handleEvent (AppEvent (SlurmCommandSend msg)) = do
     job <- fmap selectedJob <$> preuse #jobQueueState

--- a/app/UI/JobList.hs
+++ b/app/UI/JobList.hs
@@ -153,15 +153,17 @@ drawSearchBar st =
     str "Search Jobs: " <+> renderEditor (txt . T.unlines) True (st ^. #searchEditor)
 
 -- | Render the job list widget.
-drawJobList :: (Ord n, Show n) => SystemTime -> JobQueueState n -> Widget n
-drawJobList currentTime st =
-    borderWithLabel (txt . fmt $ "SLURM Queue (" +| length jobs |+ " jobs)") $
+drawJobList :: (Ord n, Show n) => SystemTime -> Maybe SystemTime -> JobQueueState n -> Widget n
+drawJobList currentTime lastUpdate st =
+    borderWithLabel (txt . fmt $ "SLURM Queue (" +| length jobs |+ " jobs, last update: " +| formatLastUpdateTime currentTime lastUpdate |+ " )") $
         renderMixedTabularList
             (defJobRenderers currentTime)
             (LstFcs True)
             (st ^. #jobListState)
   where
     jobs = listElements (st ^. #jobListState ^. #list)
+    formatLastUpdateTime _ Nothing = "never"
+    formatLastUpdateTime now (Just lastTime) = formatTime $ systemDiffTime lastTime now
 
 columnWidths :: WidthsPerRowKind Job Widths
 columnWidths = WsPerRK $ \(AvlW total) _ ->

--- a/app/UI/JobList.hs
+++ b/app/UI/JobList.hs
@@ -184,13 +184,14 @@ cellRenderer currentTime (LstFcs isFocused) (MxdCtxt _ (MColC (Ix ci))) job =
      in case ci of
             0 -> withAttr jobId . render . show $ job ^. #jobId
             1 -> render $ job ^. #name
-            2 -> render $ job ^. #account
-            3 -> styleAttribute . padRight Max . foldr (\st w -> (jobStateLabel st) <+> w) emptyWidget $ job ^. #jobState
-            4 ->
+            2 -> render $ job ^. #userName
+            3 -> render $ job ^. #account
+            4 -> styleAttribute . padRight Max . foldr (\st w -> (jobStateLabel st) <+> w) emptyWidget $ job ^. #jobState
+            5 ->
                 renderRunningTime
                     (job ^. #startTime)
                     currentTime
-            5 -> render $ (nodesFor job)
+            6 -> render $ (nodesFor job)
             _ -> emptyWidget
   where
     nodesFor :: Job -> Text
@@ -210,7 +211,7 @@ cellRenderer currentTime (LstFcs isFocused) (MxdCtxt _ (MColC (Ix ci))) job =
                     (padRight Max (txt st))
 
 columnHeaderNames :: Vector Text
-columnHeaderNames = Vec.fromList ["ID", "Name", "Account", "State", "Time", "Nodes"]
+columnHeaderNames = Vec.fromList ["ID", "Name", "User", "Account", "State", "Time", "Nodes"]
 
 columnHeaders :: MixedColHdr n Widths
 columnHeaders =

--- a/app/UI/JobPanel.hs
+++ b/app/UI/JobPanel.hs
@@ -61,6 +61,6 @@ drawJobPanel job =
                 ]
             when ("COMPLETED" `elem` (job ^. #jobState) || "FAILED" `elem` (job ^. #jobState)) $
                 tell [labeledField "Exit Code" (T.intercalate " " $ job ^. #exitCode ^. #status)]
-            when ((not . T.null) (job ^. #stateReason)) $ 
+            when ((not . T.null) (job ^. #stateReason) && (job ^. #stateReason /= "None")) $ 
                 tell [labeledField "State Reason" (job ^. #stateReason)]
 

--- a/app/UI/JobPanel.hs
+++ b/app/UI/JobPanel.hs
@@ -26,10 +26,10 @@ import Model.Job (
  )
 import Optics.Operators ((^.))
 
+import Control.Monad.Writer
 import Data.Time.Clock.System (systemToUTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import UI.Themes (jobLabel, jobState)
-import Control.Monad.Writer
 
 -- | Render detailed job panel
 drawJobPanel :: Job -> Widget n
@@ -44,8 +44,10 @@ drawJobPanel job =
         stateAttr stateName = jobState <> attrName (toString stateName)
         jobStateWidget = foldr (\stateName widget -> withAttr (stateAttr $ stateName) (txt stateName) <=> widget) emptyWidget (job ^. #jobState)
      in border . padBottom Max . padLeftRight 1 . vBox . execWriter $ do
-            tell [ hBox
-                    [ withAttr jobLabel (str "Job ID: ") , (txt . show $ job ^. #jobId)
+            tell
+                [ hBox
+                    [ withAttr jobLabel (str "Job ID: ")
+                    , (txt . show $ job ^. #jobId)
                     , withAttr jobLabel (str " State: ")
                     , jobStateWidget
                     ]
@@ -61,6 +63,5 @@ drawJobPanel job =
                 ]
             when ("COMPLETED" `elem` (job ^. #jobState) || "FAILED" `elem` (job ^. #jobState)) $
                 tell [labeledField "Exit Code" (T.intercalate " " $ job ^. #exitCode ^. #status)]
-            when ((not . T.null) (job ^. #stateReason) && (job ^. #stateReason /= "None")) $ 
+            when ((not . T.null) (job ^. #stateReason) && (job ^. #stateReason /= "None")) $
                 tell [labeledField "State Reason" (job ^. #stateReason)]
-

--- a/app/UI/JobPanel.hs
+++ b/app/UI/JobPanel.hs
@@ -18,6 +18,7 @@ import Brick (
  )
 import Brick.Widgets.Border (border)
 import qualified Data.Text as T
+import Fmt (fixedF, fmt, (+|), (|+))
 import Model.Job (
     ExitCode (..),
     Job (..),
@@ -25,7 +26,6 @@ import Model.Job (
     showWith,
  )
 import Optics.Operators ((^.))
-import Fmt (fmt, (+|), (|+), fixedF)
 
 import Control.Monad.Writer
 import Data.Time.Clock.System (systemToUTCTime)
@@ -70,11 +70,15 @@ drawJobPanel job =
     intToDouble :: Int -> Double
     intToDouble = fromIntegral
     tb :: Int
-    tb = 1024 * 1024 * 1024 * 1024
+    tb = 1024 * 1024 * 1024
     gb :: Int
-    gb = 1024 * 1024 * 1024
-    humanReadable mem = fmt $
-        if mem > tb then
-            fixedF 1 (intToDouble mem / intToDouble tb) +| " TB"
-        else if mem > gb then (fixedF 1 (intToDouble mem / intToDouble gb) +| " GB")
-        else "" +| mem |+ " MB"
+    gb = 1024 * 1024
+    humanReadable mem =
+        fmt $
+            if mem > tb
+                then
+                    fixedF 1 (intToDouble mem / intToDouble tb) +| " TB"
+                else
+                    if mem > gb
+                        then (fixedF 1 (intToDouble mem / intToDouble gb) +| " GB")
+                        else "" +| mem |+ " MB"

--- a/app/UI/JobPanel.hs
+++ b/app/UI/JobPanel.hs
@@ -70,9 +70,9 @@ drawJobPanel job =
     intToDouble :: Int -> Double
     intToDouble = fromIntegral
     tb :: Int
-    tb = 1024 * 1024 * 1024
+    tb = 1024 * 1024
     gb :: Int
-    gb = 1024 * 1024
+    gb = 1024
     humanReadable mem =
         fmt $
             if mem > tb

--- a/app/UI/View.hs
+++ b/app/UI/View.hs
@@ -32,7 +32,7 @@ drawApp st =
     (if st ^. #showLog then [drawSlurmCommandLog (st ^. #scontrolLogState)] else [])
         <> [ vBox
                 [ (drawSearchBar (st ^. #jobQueueState) <=> hBorder)
-                , (drawJobList (st ^. #currentTime) (st ^. #jobQueueState) <+> maybe emptyWidget drawJobPanel (selectedJob (st ^. #jobQueueState)))
+                , (drawJobList (st ^. #currentTime) (st ^. #lastUpdate) (st ^. #jobQueueState) <+> maybe emptyWidget drawJobPanel (selectedJob (st ^. #jobQueueState)))
                 , maybe emptyWidget drawTransientView (st ^. #transient)
                 , drawEchoBuffer (st ^. #echoState)
                 ]

--- a/slew.cabal
+++ b/slew.cabal
@@ -70,7 +70,7 @@ executable slew
     default-extensions: OverloadedStrings DeriveGeneric NoFieldSelectors DuplicateRecordFields OverloadedRecordDot OverloadedLabels
 
     -- Other library packages from which modules are imported.
-    build-depends:    base >= 4.19.2.0, relude, brick, vector, vty, fmt, linear, aeson, vty-crossplatform, bytestring, process, time, rosezipper, aeson-casing, async, hinotify, text, stm, text-zipper, optparse-applicative, brick-tabular-list, optics-core, optics-extra, filepath
+    build-depends:    base >= 4.19.2.0, relude, brick, vector, vty, fmt, linear, aeson, vty-crossplatform, bytestring, process, time, rosezipper, aeson-casing, async, hinotify, text, stm, text-zipper, optparse-applicative, brick-tabular-list, optics-core, optics-extra, filepath, mtl
 
     -- Directories containing source files.
     hs-source-dirs:   app


### PR DESCRIPTION
Improving the job list by:

1. Using human readable resource names (1.0GB)
2. Selectively showing the exit code and state reason only if there is something relevant to show. 
3. Rebind quit to C-q to allow searching for the letter q
4. Show job user name
5. Manual job refreshing
6. Job stale time counter
7. Fixed formatting of times (submit_time appears to be in minutes rather than seconds but this is undocumented...)