### PR TITLE
Refactor view and event routing logic for extensibility

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -1,8 +1,8 @@
 #+title: Slew Project TODO
 * Backlog
-** TODO Log shell command outputs
-** TODO Report shell command errors
-
+** DONE Log shell command outputs
+** DONE Report shell command errors
+* Refactoring
 * Roadmap
 **  Tier 0 — Core SLURM Features
 *** DONE Job table
@@ -14,17 +14,17 @@ Modal or split-pane detail view conditionally shown in View based on selected jo
 *** DONE Cancel job
 Msg triggered on keypress, update triggers external IO via Cmd (calls scancel)
 ** Tier 1 — Low-Hanging UX Wins
-*** TODO Automatic Release Builds
+*** DONE Automatic Release Builds
 *** DONE Log view for commands
 Probably need an echo area
-*** TODO Properly tabulated list
+*** DONE Properly tabulated list
 *** TODO Resubmit/clone job
 Pressing key → emit Msg → handler constructs sbatch string and spawns a Cmd
 *** TODO Export to CSV
 Cmd that writes to file or clipboard, possibly triggered by Msg
 *** DONE Log preview (tail)
 Use Cmd to spawn tail process → output read into Msg → render in scrollable window
-*** TODO Pending reason
+*** DONE Pending reason
 On select or hover, fetch with Cmd, cached in state (Map JobId Reason)
 ** Tier 2 — Interactive and Composable
 *** TODO Live CPU/RAM on Job
@@ -35,7 +35,7 @@ Maintain a timestamped event log per job in model, render as a bar/timeline
 Managed like "named presets", a list of templates in model, pick with a list view
 *** TODO File outputs
 Use job metadata to show clickable filenames or paths → render preview on select
-*** TODO Interactive search bar
+*** DONE Interactive search bar
 Composable widget (like textbox) → on change, updates filter state in parent
 ** Tier 3 — State-Rich Components
 *** TODO Cluster grid view

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,7 +28,7 @@ import SQueue.Poller (squeueThread)
 import System.Environment.Blank (getEnv)
 import System.FilePath (combine)
 import UI.Echo (echo)
-import UI.Event (handleEventWithEcho)
+import UI.Event (handleEvent)
 import UI.SlurmCommand (SlurmCommandLogEntry (..), SlurmCommandLogState (..), startSlurmCommandListener)
 import UI.Themes (defaultTheme, loadTheme)
 import UI.View (drawApp)
@@ -41,7 +41,7 @@ app init' theme =
     App
         { appDraw = drawApp
         , appChooseCursor = showFirstCursor
-        , appHandleEvent = handleEventWithEcho
+        , appHandleEvent = handleEvent
         , appStartEvent = init'
         , appAttrMap = const (themeToAttrMap theme)
         }

--- a/app/Model/AppState.hs
+++ b/app/Model/AppState.hs
@@ -4,6 +4,7 @@ module Model.AppState (
     Command (..),
     Category (..),
     Name (..),
+    View (..),
     initialState,
 ) where
 
@@ -27,8 +28,11 @@ data Command = Cancel | Suspend | Resume | Hold | Release | Top deriving (Show)
 data Category = Account | CPUs | StartTime | EndTime | JobName | UserName | Memory deriving (Show)
 data SlewEvent = SQueueStatus [Job] | SlurmCommandSend Command | SlurmCommandReceive SlurmCommandLogEntry | SortBy Category | Tick deriving (Show)
 
-data Name = SearchEditor | JobListWidget | SlurmCommandLogView | TransientView
+data Name = SearchEditor | JobListWidget | SlurmCommandLogWidget | TransientWidget
     deriving (Eq, Ord, Show)
+
+data View = SQueueView | CommandLogView | NodeView
+    deriving (Eq, Show)
 
 ------------------------------------------------------------
 -- App State
@@ -43,6 +47,7 @@ data AppState = AppState
     , showLog ::
         Bool
     , echoState :: EchoState
+    , view :: View
     }
     deriving (Generic)
 
@@ -62,9 +67,10 @@ initialState = do
             { jobQueueState = jobList SearchEditor JobListWidget
             , transient = Nothing
             , squeueChannel = squeueChannel'
-            , scontrolLogState = scontrolLog SlurmCommandLogView scontrolCommandChannel
+            , scontrolLogState = scontrolLog SlurmCommandLogWidget scontrolCommandChannel
             , showLog = False
             , currentTime = currentTime'
             , lastUpdate = Nothing
             , echoState = echoStateWith initialMessage
+            , view = SQueueView
             }

--- a/app/Model/AppState.hs
+++ b/app/Model/AppState.hs
@@ -47,7 +47,7 @@ data AppState = AppState
     , lastUpdate :: Maybe SystemTime
     , showLog :: Bool
     , echoState :: EchoState
-    , view :: [View]
+    , view :: NonEmpty View
     , options :: Options
     }
     deriving (Generic)
@@ -73,6 +73,6 @@ initialState options = do
             , currentTime = currentTime'
             , lastUpdate = Nothing
             , echoState = echoStateWith initialMessage
-            , view = [SQueueView]
+            , view = SQueueView :| []
             , options = options
             }

--- a/app/Model/AppState.hs
+++ b/app/Model/AppState.hs
@@ -47,7 +47,7 @@ data AppState = AppState
     , showLog ::
         Bool
     , echoState :: EchoState
-    , view :: View
+    , view :: [View]
     }
     deriving (Generic)
 
@@ -72,5 +72,5 @@ initialState = do
             , currentTime = currentTime'
             , lastUpdate = Nothing
             , echoState = echoStateWith initialMessage
-            , view = SQueueView
+            , view = [SQueueView]
             }

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -191,6 +191,7 @@ handleEvent (AppEvent Tick) = do
 handleEvent (AppEvent (SQueueStatus jobs)) = zoom #jobQueueState (updateJobList jobs) >> bumpUpdateTime
 handleEvent (VtyEvent (V.EvKey (V.KChar 'q') [V.MCtrl])) = halt
 handleEvent (VtyEvent (V.EvKey (V.KChar 'l') [V.MCtrl])) = pushView CommandLogView
+handleEvent (VtyEvent (V.EvKey (V.KChar 'n') [V.MCtrl])) = pushView NodeView
 handleEvent e = do
     curView <- use #view
     handled <- case curView of

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -7,6 +7,7 @@ import Brick.BChan (writeBChan)
 import Brick.Widgets.Core (withAttr)
 import Data.List.NonEmpty ((<|))
 import Data.Time.Clock.System (getSystemTime)
+import Fmt
 import qualified Graphics.Vty as V
 import Model.AppState (
     AppState (..),
@@ -203,5 +204,6 @@ handleEvent e = do
         SQueueView -> handleSQueueViewEvent e
         CommandLogView -> handleCommandLogViewEvent e
         NodeView -> handleNodeViewEvent e
+    putTextLn . fmt $ "Did I handle it? " +| handled |+ ""
     when (not handled) (handleGlobalEvent e)
     when (isKeyPress e) (zoom #echoState clear)

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -139,7 +139,7 @@ handleSQueueViewEvent (VtyEvent e) = do
         Just TR.Close -> #transient .= Nothing >> pure True
         Just (TR.Msg msg') -> #transient .= Nothing >> handleSQueueViewEvent (AppEvent msg')
         Just TR.Next -> pure True
-        _ -> zoom #jobQueueState (handleJobQueueEvent e) >> pure True
+        _ -> zoom #jobQueueState (handleJobQueueEvent e)
 handleSQueueViewEvent (AppEvent (SortBy category)) = zoom #jobQueueState (updateSortKey (sortListByCat category)) >> pure True
 handleSQueueViewEvent (AppEvent (SlurmCommandSend msg)) = do
     job <- fmap selectedJob <$> preuse #jobQueueState

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -13,7 +13,7 @@ import Model.AppState (
     Command (Cancel, Hold, Release, Resume, Suspend, Top),
     Name,
     SlewEvent (..),
-    View (..)
+    View (..),
  )
 import Model.Job (
     Job (..),
@@ -168,9 +168,8 @@ isKeyPress :: BrickEvent Name SlewEvent -> Bool
 isKeyPress (VtyEvent (V.EvKey _ _)) = True
 isKeyPress _ = False
 
-
 pushView :: View -> EventM Name AppState ()
-pushView newView = #view %= (newView:)
+pushView newView = #view %= (newView :)
 
 popView :: EventM Name AppState ()
 popView = #view %= drop 1
@@ -191,15 +190,12 @@ handleEvent (AppEvent Tick) = do
 handleEvent (AppEvent (SQueueStatus jobs)) = zoom #jobQueueState (updateJobList jobs) >> bumpUpdateTime
 handleEvent (VtyEvent (V.EvKey (V.KChar 'q') [V.MCtrl])) = halt
 handleEvent (VtyEvent (V.EvKey (V.KChar 'l') [V.MCtrl])) = pushView CommandLogView
-handleEvent (VtyEvent (V.EvKey (V.KChar 'n') [V.MCtrl])) = pushView NodeView
 handleEvent e = do
     curView <- use #view
     handled <- case curView of
-        (SQueueView:_) -> handleSQueueViewEvent e
-        (CommandLogView:_) -> handleCommandLogViewEvent e
-        (NodeView:_) -> handleNodeViewEvent e
+        (SQueueView : _) -> handleSQueueViewEvent e
+        (CommandLogView : _) -> handleCommandLogViewEvent e
+        (NodeView : _) -> handleNodeViewEvent e
         [] -> pure False
     when (not handled && isEscape e) (popView >> haltIfNoFocus)
     when (isKeyPress e) (zoom #echoState clear)
-
-        

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -204,6 +204,5 @@ handleEvent e = do
         SQueueView -> handleSQueueViewEvent e
         CommandLogView -> handleCommandLogViewEvent e
         NodeView -> handleNodeViewEvent e
-    putTextLn . fmt $ "Did I handle it? " +| handled |+ ""
     when (not handled) (handleGlobalEvent e)
     when (isKeyPress e) (zoom #echoState clear)

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -1,5 +1,5 @@
 module UI.Event (
-    handleEventWithEcho,
+    handleEvent,
 ) where
 
 import Brick (BrickEvent (AppEvent, VtyEvent), EventM, halt, nestEventM, txt, zoom)
@@ -13,6 +13,7 @@ import Model.AppState (
     Command (Cancel, Hold, Release, Resume, Suspend, Top),
     Name,
     SlewEvent (..),
+    View (..)
  )
 import Model.Job (
     Job (..),
@@ -107,11 +108,6 @@ zoomTransient e = do
             pure msg
         Nothing -> pure mempty
 
--- | Main event handler
-handleEventWithEcho :: BrickEvent Name SlewEvent -> EventM Name AppState ()
-handleEventWithEcho e@(VtyEvent (V.EvKey _ _)) = zoom #echoState clear >> handleEvent e
-handleEventWithEcho e = handleEvent e
-
 handleJobFile :: Lens' Job FilePath -> EventM Name AppState ()
 handleJobFile field = do
     mJob <- selectedJob <$> use #jobQueueState
@@ -119,40 +115,34 @@ handleJobFile field = do
         result <- tailFile (job ^. field)
         either (zoom #echoState . echo) (const (pure ())) result
 
-handleEvent :: BrickEvent Name SlewEvent -> EventM Name AppState ()
-handleEvent (VtyEvent (V.EvKey (V.KChar 'l') [V.MCtrl])) = #showLog %= not
-handleEvent (VtyEvent e@(V.EvKey V.KEsc [])) = do
-    msg <- getFirst <$> (zoomTransient e)
-    showingLog <- use #showLog
-
-    case (showingLog, msg) of
-        (True, _) -> #showLog .= False
-        (False, Just TR.Close) -> #transient .= Nothing
-        _ -> halt
-handleEvent (VtyEvent (V.EvKey (V.KChar 'q') [V.MCtrl])) = halt
-handleEvent (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl])) =
-    #transient .= Just scontrolTransient -- could parameterise this
-handleEvent (VtyEvent (V.EvKey (V.KChar 'o') [V.MCtrl])) = handleJobFile #standardOutput
-handleEvent (VtyEvent (V.EvKey (V.KChar 'e') [V.MCtrl])) = handleJobFile #standardError
-handleEvent (VtyEvent (V.EvKey (V.KChar 'r') [V.MCtrl])) = triggerSqueue
-handleEvent (VtyEvent (V.EvKey (V.KChar 's') [V.MCtrl])) =
-    #transient .= Just sortTransient -- could parameterise this
-handleEvent (VtyEvent e) = do
+handleSQueueViewEvent :: BrickEvent Name SlewEvent -> EventM Name AppState Bool
+handleSQueueViewEvent (VtyEvent e@(V.EvKey V.KEsc [])) = do
     msg <- getFirst <$> (zoomTransient e)
     case msg of
-        Just TR.Close -> #transient .= Nothing
-        Just (TR.Msg msg') -> #transient .= Nothing >> handleEvent (AppEvent msg')
-        Just TR.Next -> pure ()
-        _ -> zoom #jobQueueState (handleJobQueueEvent e)
-handleEvent (AppEvent (SQueueStatus jobs)) = zoom #jobQueueState (updateJobList jobs) >> bumpUpdateTime
-handleEvent (AppEvent (SortBy category)) = zoom #jobQueueState (updateSortKey (sortListByCat category))
-handleEvent (AppEvent (SlurmCommandSend msg)) = do
+        Just TR.Close -> #transient .= Nothing >> pure True
+        _ -> pure False
+handleSQueueViewEvent (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl])) =
+    #transient .= Just scontrolTransient >> pure True -- could parameterise this
+handleSQueueViewEvent (VtyEvent (V.EvKey (V.KChar 'o') [V.MCtrl])) = handleJobFile #standardOutput >> pure True
+handleSQueueViewEvent (VtyEvent (V.EvKey (V.KChar 'e') [V.MCtrl])) = handleJobFile #standardError >> pure True
+handleSQueueViewEvent (VtyEvent (V.EvKey (V.KChar 'r') [V.MCtrl])) = triggerSqueue >> pure True
+handleSQueueViewEvent (VtyEvent (V.EvKey (V.KChar 's') [V.MCtrl])) =
+    #transient .= Just sortTransient >> pure True -- could parameterise this
+handleSQueueViewEvent (VtyEvent e) = do
+    msg <- getFirst <$> (zoomTransient e)
+    case msg of
+        Just TR.Close -> #transient .= Nothing >> pure True
+        Just (TR.Msg msg') -> #transient .= Nothing >> handleSQueueViewEvent (AppEvent msg')
+        Just TR.Next -> pure True
+        _ -> zoom #jobQueueState (handleJobQueueEvent e) >> pure True
+handleSQueueViewEvent (AppEvent (SortBy category)) = zoom #jobQueueState (updateSortKey (sortListByCat category)) >> pure True
+handleSQueueViewEvent (AppEvent (SlurmCommandSend msg)) = do
     job <- fmap selectedJob <$> preuse #jobQueueState
     case join job of
         Just job' -> do
             let cmd = scontrolCommand msg job'
-            zoom #scontrolLogState (sendSlurmCommandCommand cmd)
-        Nothing -> pure ()
+            zoom #scontrolLogState (sendSlurmCommandCommand cmd) >> pure True
+        Nothing -> pure False
   where
     scontrolCommand :: Command -> Job -> SlurmCommandCmd
     scontrolCommand Cancel job = CancelJob [job ^. #jobId]
@@ -161,6 +151,23 @@ handleEvent (AppEvent (SlurmCommandSend msg)) = do
     scontrolCommand Hold job = HoldJob [job ^. #jobId]
     scontrolCommand Release job = ReleaseJob [job ^. #jobId]
     scontrolCommand Top job = TopJob [job ^. #jobId]
+handleSQueueViewEvent _ = pure False
+
+handleCommandLogViewEvent :: BrickEvent Name SlewEvent -> EventM Name AppState Bool
+handleCommandLogViewEvent = const (pure False)
+
+handleNodeViewEvent :: BrickEvent Name SlewEvent -> EventM Name AppState Bool
+handleNodeViewEvent = const (pure False)
+
+isEscape :: BrickEvent Name SlewEvent -> Bool
+isEscape (VtyEvent (V.EvKey V.KEsc [])) = True
+isEscape _ = False
+
+isKeyPress :: BrickEvent Name SlewEvent -> Bool
+isKeyPress (VtyEvent (V.EvKey _ _)) = True
+isKeyPress _ = False
+
+handleEvent :: BrickEvent Name SlewEvent -> EventM Name AppState ()
 handleEvent (AppEvent (SlurmCommandReceive output@(SlurmCommandLogEntry{result = Left _}))) = zoom #echoState (echo errorMessage) >> zoom #scontrolLogState (logSlurmCommandEvent output) >> triggerSqueue
   where
     errorMessage = "command failed, type C-l to see output"
@@ -168,4 +175,15 @@ handleEvent (AppEvent (SlurmCommandReceive output)) = zoom #scontrolLogState (lo
 handleEvent (AppEvent Tick) = do
     sysTime <- liftIO getSystemTime
     #currentTime .= sysTime
-handleEvent _ = pure ()
+handleEvent (AppEvent (SQueueStatus jobs)) = zoom #jobQueueState (updateJobList jobs) >> bumpUpdateTime
+handleEvent (VtyEvent (V.EvKey (V.KChar 'q') [V.MCtrl])) = halt
+handleEvent e = do
+    curView <- use #view
+    handled <- case curView of
+        SQueueView -> handleSQueueViewEvent e
+        CommandLogView -> handleCommandLogViewEvent e
+        NodeView -> handleNodeViewEvent e
+    when (not handled && isEscape e) halt
+    when (isKeyPress e) (zoom #echoState clear)
+
+        

--- a/app/UI/Event.hs
+++ b/app/UI/Event.hs
@@ -120,6 +120,7 @@ handleSQueueViewEvent (VtyEvent e@(V.EvKey V.KEsc [])) = do
     msg <- getFirst <$> (zoomTransient e)
     case msg of
         Just TR.Close -> #transient .= Nothing >> pure True
+        Just TR.Up -> pure True
         _ -> pure False
 handleSQueueViewEvent (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl])) =
     #transient .= Just scontrolTransient >> pure True -- could parameterise this

--- a/app/UI/JobList.hs
+++ b/app/UI/JobList.hs
@@ -223,7 +223,37 @@ columnHeaders =
         , height = ColHdrH 2
         }
 
-handleJobQueueEvent :: (Ord n, Show n) => V.Event -> EventM n (JobQueueState n) ()
-handleJobQueueEvent e@(V.EvKey V.KUp []) = zoom #jobListState (handleMixedListEvent e)
-handleJobQueueEvent e@(V.EvKey V.KDown []) = zoom #jobListState (handleMixedListEvent e)
-handleJobQueueEvent e = zoom #searchEditor (handleEditorEvent (VtyEvent e)) >> updateListState
+isEditorCommand :: V.Event -> Bool
+isEditorCommand (V.EvKey key mods) =
+    case (key, mods) of
+        (V.KEnter, []) -> True
+        (V.KDel, []) -> True
+        (V.KBS, []) -> True
+        (V.KHome, []) -> True
+        (V.KEnd, []) -> True
+        (V.KChar '<', [V.MMeta]) -> True
+        (V.KChar '>', [V.MMeta]) -> True
+        (V.KChar 'a', [V.MCtrl]) -> True
+        (V.KChar 'e', [V.MCtrl]) -> True
+        (V.KChar 'd', [V.MCtrl]) -> True
+        (V.KChar 'd', [V.MMeta]) -> True
+        (V.KChar 'k', [V.MCtrl]) -> True
+        (V.KChar 'u', [V.MCtrl]) -> True
+        (V.KChar 't', [V.MCtrl]) -> True
+        (V.KChar c, []) | c /= '\t' -> True
+        (V.KUp, []) -> True
+        (V.KDown, []) -> True
+        (V.KLeft, []) -> True
+        (V.KRight, []) -> True
+        (V.KChar 'b', [V.MCtrl]) -> True
+        (V.KChar 'f', [V.MCtrl]) -> True
+        (V.KChar 'b', [V.MMeta]) -> True
+        (V.KChar 'f', [V.MMeta]) -> True
+        _ -> False
+isEditorCommand (V.EvPaste _) = True
+isEditorCommand _ = False
+
+handleJobQueueEvent :: (Ord n, Show n) => V.Event -> EventM n (JobQueueState n) Bool
+handleJobQueueEvent e@(V.EvKey V.KUp []) = zoom #jobListState (handleMixedListEvent e) >> pure True
+handleJobQueueEvent e@(V.EvKey V.KDown []) = zoom #jobListState (handleMixedListEvent e) >> pure True
+handleJobQueueEvent e = zoom #searchEditor (handleEditorEvent (VtyEvent e)) >> updateListState >> pure (isEditorCommand e)

--- a/app/UI/View.hs
+++ b/app/UI/View.hs
@@ -9,8 +9,8 @@ module UI.View (
 import Brick (
     Widget,
     emptyWidget,
-    vBox,
     txt,
+    vBox,
     (<+>),
     (<=>),
  )
@@ -20,7 +20,7 @@ import Optics.Operators ((^.))
 import Model.AppState (
     AppState (..),
     Name (..),
-    View (..)
+    View (..),
  )
 import UI.Echo (drawEchoBuffer)
 import UI.JobList (drawJobList, drawSearchBar, selectedJob)
@@ -30,15 +30,16 @@ import UI.Transient (drawTransientView)
 
 -- | Top-level renderer for the entire application.
 drawAppView :: [View] -> AppState -> [Widget Name]
-drawAppView (SQueueView:_) st = [ vBox
-                    [ (drawSearchBar (st ^. #jobQueueState) <=> hBorder)
-                    , (drawJobList (st ^. #currentTime) (st ^. #lastUpdate) (st ^. #jobQueueState) <+> maybe emptyWidget drawJobPanel (selectedJob (st ^. #jobQueueState)))
-                    , maybe emptyWidget drawTransientView (st ^. #transient)
-                    ]]
-drawAppView (CommandLogView:_) st = [drawSlurmCommandLog (st ^. #scontrolLogState)]
-drawAppView (NodeView:_) st = [txt "Nothing here yet!"] 
+drawAppView (SQueueView : _) st =
+    [ vBox
+        [ (drawSearchBar (st ^. #jobQueueState) <=> hBorder)
+        , (drawJobList (st ^. #currentTime) (st ^. #lastUpdate) (st ^. #jobQueueState) <+> maybe emptyWidget drawJobPanel (selectedJob (st ^. #jobQueueState)))
+        , maybe emptyWidget drawTransientView (st ^. #transient)
+        ]
+    ]
+drawAppView (CommandLogView : _) st = [drawSlurmCommandLog (st ^. #scontrolLogState)]
+drawAppView (NodeView : _) st = [txt "Nothing here yet!"]
 drawAppView _ _ = [emptyWidget]
-
 
 drawApp :: AppState -> [Widget Name]
 drawApp st = [vBox (drawAppView (st ^. #view) st <> [drawEchoBuffer (st ^. #echoState)])]

--- a/app/UI/View.hs
+++ b/app/UI/View.hs
@@ -9,7 +9,6 @@ module UI.View (
 import Brick (
     Widget,
     emptyWidget,
-    txt,
     vBox,
     (<+>),
     (<=>),
@@ -29,16 +28,16 @@ import UI.SlurmCommand (drawSlurmCommandLog)
 import UI.Transient (drawTransientView)
 
 -- | Top-level renderer for the entire application.
-drawAppView :: [View] -> AppState -> [Widget Name]
-drawAppView (SQueueView : _) st =
+drawAppView :: View -> AppState -> [Widget Name]
+drawAppView SQueueView st =
     [ vBox
         [ (drawSearchBar (st ^. #jobQueueState) <=> hBorder)
         , (drawJobList (st ^. #currentTime) (st ^. #lastUpdate) (st ^. #jobQueueState) <+> maybe emptyWidget drawJobPanel (selectedJob (st ^. #jobQueueState)))
         , maybe emptyWidget drawTransientView (st ^. #transient)
         ]
     ]
-drawAppView (CommandLogView : _) st = [drawSlurmCommandLog (st ^. #scontrolLogState)]
+drawAppView CommandLogView st = [drawSlurmCommandLog (st ^. #scontrolLogState)]
 drawAppView _ _ = [emptyWidget]
 
 drawApp :: AppState -> [Widget Name]
-drawApp st = [vBox (drawAppView (st ^. #view) st <> [drawEchoBuffer (st ^. #echoState)])]
+drawApp st = [vBox (drawAppView (head (st ^. #view)) st <> [drawEchoBuffer (st ^. #echoState)])]

--- a/app/UI/View.hs
+++ b/app/UI/View.hs
@@ -38,7 +38,6 @@ drawAppView (SQueueView : _) st =
         ]
     ]
 drawAppView (CommandLogView : _) st = [drawSlurmCommandLog (st ^. #scontrolLogState)]
-drawAppView (NodeView : _) st = [txt "Nothing here yet!"]
 drawAppView _ _ = [emptyWidget]
 
 drawApp :: AppState -> [Widget Name]


### PR DESCRIPTION
Refactors view and event routing logic to delegate to different `handleEvent` functions depending on a view stack that maintains the list of views, top-most being the current view. The escape key now pops views off the stack, and closes if the stack is a singleton (last view). Global commands like `C-q` can be called from any view, but are passed to the current view event handler first. If the current view event handler returns `True` that event is swallowed and not processed by the global event handler.